### PR TITLE
Fix LateInitializationError for points animation

### DIFF
--- a/lib/src/screens/home_screen.dart
+++ b/lib/src/screens/home_screen.dart
@@ -17,7 +17,7 @@ class _HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin {
   List<bool> _checkedGoals = [];
   bool _isLoading = true;
   late AnimationController _pointsController;
-  late Animation<int> _pointsAnimation;
+  Animation<int>? _pointsAnimation;
 
   @override
   void initState() {
@@ -105,7 +105,7 @@ class _HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin {
       
       // 设置积分动画
       _pointsAnimation = IntTween(
-        begin: _pointsAnimation.value,
+        begin: _pointsAnimation?.value ?? 0,
         end: points,
       ).animate(_pointsController);
       _pointsController.forward(from: 0.0);


### PR DESCRIPTION
## Summary
- allow the points animation to be nullable so the screen can render before it is initialized
- update animation tweens to safely read the current value when available

## Testing
- Not run (flutter is not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68de766ace7083208da3466cdb228680